### PR TITLE
Fix API Docs Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Table of contents
 
-* [API Documentation](./docs/api)
+* [API Documentation](docs/api.md)
 * [How it works](#how-it-works)
 * [Getting started](#getting-started)
 * [Errors in behaviors](#errors-in-behaviors)


### PR DESCRIPTION
Fixes the API Documentation link in the Readme so it goes t the correct path.
