### PR TITLE
Switch Observations to use High Resolution Time

### DIFF
--- a/src/observation.coffee
+++ b/src/observation.coffee
@@ -10,7 +10,9 @@ class Observation
   constructor: (name, block, options={}) ->
     @name = name
     @_options = options
-    @startTime = options.startTime ? new Date()
+    # If we don't have a startTime, grab the current high-resolution real time
+    # which is a tuple array. See: https://nodejs.org/api/process.html#process_process_hrtime
+    @startTime = options.startTime ? process.hrtime()
 
     # Runs the block on construction
     try
@@ -18,7 +20,10 @@ class Observation
     catch error
       @error = error
 
-    @duration = Date.now() - @startTime
+    # duration is a tuple array, which has the first value as `seconds` and the second as `nanoseconds`.
+    # This is left as the tuple so that it can interpreted by whomever is processing the results
+    # Also, startTime has to remain a tuple since it is re-used with Promises or when mapping multiple experiments.
+    @duration = process.hrtime(@startTime)
 
     # Immutable
     Object.freeze(@)

--- a/test/observation.coffee
+++ b/test/observation.coffee
@@ -37,12 +37,14 @@ describe "Observation", ->
       # Just freeze time
       time =>
         observation = new Observation(@name, @return)
-        observation.should.have.property('startTime', new Date())
+        observation.should.have.property('startTime')
+        .with.lengthOf(2)
 
     it "exposes the duration", ->
       time (tick) =>
         observation = new Observation @name, -> tick(10)
-        observation.should.have.property('duration', 10)
+        observation.should.have.property('duration')
+        .with.lengthOf(2)
 
     describe "running the block", ->
       it "exposes returned results", ->
@@ -133,7 +135,12 @@ describe "Observation", ->
         settled = observation.settle()
 
         settled.should.eventually.have
-        .property('duration', 20)
+        .property('duration')
+        .and.have.lengthOf(2)
+
+        settled.should.eventually.have
+        .property('duration')
+        .and.have.lengthOf(2)
 
      it "does not call the block again", ->
        block = sinon.spy()

--- a/test/observation.coffee
+++ b/test/observation.coffee
@@ -37,14 +37,12 @@ describe "Observation", ->
       # Just freeze time
       time =>
         observation = new Observation(@name, @return)
-        observation.should.have.property('startTime')
-        .with.lengthOf(2)
+        observation.should.have.property('startTime', new Date())
 
     it "exposes the duration", ->
       time (tick) =>
         observation = new Observation @name, -> tick(10)
-        observation.should.have.property('duration')
-        .with.lengthOf(2)
+        observation.should.have.property('duration', 0)
 
     describe "running the block", ->
       it "exposes returned results", ->
@@ -128,19 +126,25 @@ describe "Observation", ->
         settled.should.eventually.have
         .property('startTime', observation.startTime)
 
+    it "preserves start tuple", ->
+      time (tick) =>
+        observation = new Observation(@name, @return, @options)
+        tick(10)
+        settled = observation.settle()
+
+        settled.should.eventually.have
+        .property('_startTuple', observation._startTuple)
+
     it "computes total duration", ->
       time (tick) =>
         observation = new Observation(@name, (-> tick(10)), @options)
         tick(10)
         settled = observation.settle()
 
+        # aboveOrEqual is here because the execution time varies
         settled.should.eventually.have
         .property('duration')
-        .and.have.lengthOf(2)
-
-        settled.should.eventually.have
-        .property('duration')
-        .and.have.lengthOf(2)
+        .which.is.aboveOrEqual(0)
 
      it "does not call the block again", ->
        block = sinon.spy()


### PR DESCRIPTION
Switched observations to use the High Resolution time. The reason for this is because `hrtime` is relative to an arbitrary time in the past (aka not related to the current time) so it is not subject to clock drift.

To provide some context, this is the [`process.hrtime()`](https://nodejs.org/api/process.html#process_process_hrtime) method which is implemented on a per-platform basis within `libuv` in Node.  You can see some docs around the `libuv` portion [here](https://raw.githubusercontent.com/nodejs/node/69b94ec55cb0f8bd90475b5b7dabd57beb7e7dfe/deps/uv/docs/src/misc.rst) as well.
