### PR TITLE
Fix duration disparities in synchronous experiments

### DIFF
--- a/src/measurement.coffee
+++ b/src/measurement.coffee
@@ -1,0 +1,34 @@
+class Stopwatch
+  constructor: -> @reset()
+
+  reset: ->
+    @_start = new Date()
+
+  time: ->
+    Date.now() - @_start
+
+class Measurement
+  constructor: (stopwatch) ->
+    @_stopwatch = stopwatch
+    @elapsed = stopwatch.time()
+
+    # Immutable
+    Object.freeze(@)
+
+  # A new measurement from no point in time
+  @benchmark: (block) ->
+    stopwatch = new Stopwatch()
+    block()
+    new Measurement(stopwatch)
+
+  # Extend an old measurement through the execution of the new block
+  remeasure: (block) ->
+    block()
+    new Measurement(@_stopwatch)
+
+  # Run the new block and return the same measurement
+  preserve: (block) ->
+    block()
+    return @
+
+module.exports = Measurement

--- a/test/measurement.coffee
+++ b/test/measurement.coffee
@@ -1,0 +1,48 @@
+_ = require('underscore')
+sinon = require('sinon')
+
+Measurement = require('../src/measurement')
+
+time = require('./helpers/time')
+
+describe "Measurement", ->
+  beforeEach ->
+    @measurement = Measurement.benchmark(->)
+  describe ".benchmark()", ->
+    it "runs a block and returns a new measurement", ->
+      block = sinon.spy()
+      measurement = Measurement.benchmark(block)
+
+      block.should.be.calledOnce()
+      measurement.should.be.instanceof(Measurement)
+
+    it "captures the time elapsed", ->
+      time (tick) ->
+        measurement = Measurement.benchmark -> tick(10)
+        measurement.elapsed.should.equal(10)
+
+  describe "::remeasure()", ->
+    it "calls the block and returns a new measurement", ->
+      block = sinon.spy()
+      remeasurement = @measurement.remeasure(block)
+
+      block.should.be.calledOnce()
+      remeasurement.should.be.instanceof(Measurement)
+      remeasurement.should.not.equal(@measurement)
+
+    it "extends the elapsed time to the end of the new block", ->
+      time (tick) =>
+        measurement = Measurement.benchmark -> tick(10)
+        tick(10)
+        remeasurement = measurement.remeasure -> tick(10)
+
+        remeasurement.elapsed.should.equal(30)
+
+  describe "::preserve()", ->
+    it "calls the block and returns the same measurement", ->
+      block = sinon.spy()
+      remeasurement = @measurement.preserve(block)
+
+      block.should.be.calledOnce()
+      remeasurement.should.be.instanceof(Measurement)
+      remeasurement.should.equal(@measurement)

--- a/test/observation.coffee
+++ b/test/observation.coffee
@@ -166,6 +166,15 @@ describe "Observation", ->
 
       (=> observation.map(@throw)).should.throw(@error)
 
+    it "does not change the run duration", ->
+      observation = new Observation(@name, @return, @options)
+      duration = observation.duration
+
+      time (tick) =>
+        mapped = observation.map -> tick(1000)
+
+        mapped.duration.should.equal(duration)
+
   describe "::didReturn()", ->
     it "returns true if the block returned", ->
       observation = new Observation(@name, @return)


### PR DESCRIPTION
This is a work in progress. The issue we're trying to solve here is the
fact that measuring synchronous and asynchronous observations is
different, which is annoying. This implementation decouples the timing
from the observation a bit in a way that each observation can be
constructed with a slightly different timing mechanism.

The initial observation is constructed with 'benchmark', which is simply
the synchronous execution time. The mapped observation is constructed
with 'preserve', which ignores extra execution time. Finally the settled
observation (async only) is constructed with 'remeasure', which means
the whole time from initial execution to promise resolution is used.

Things I like:
- Abstraction of the stopwatch means we can switch to hrtime() pretty
  easily and also mock in tests easily too
- The parallelism of "a function that takes a block and returns a time
  in milliseconds" is a nice way to think about the problem

Things I am not entirely happy about:
- An extra Observation parameter and probably doesn't belong in options?
- Does not address startTime elegantly, but this isn't a huge deal with
  the deprecation
- Something makes me feel like stopwatch and/or measurement is a little
  redundant in a way that I can't see right now because I've gone
  through too many iterations.

Fixes #3
