### PR TITLE
use high res timers for observations

### DIFF
--- a/src/measurement.coffee
+++ b/src/measurement.coffee
@@ -2,10 +2,13 @@ class Stopwatch
   constructor: -> @reset()
 
   reset: ->
-    @_start = new Date()
+    @_start = process.hrtime()
 
   time: ->
-    Date.now() - @_start
+    @_hrToMs(process.hrtime(@_start))
+
+  _hrToMs: ([seconds, nanoseconds]) ->
+    Math.round(seconds * 1e3 + nanoseconds / 1e6)
 
 class Measurement
   constructor: (stopwatch) ->

--- a/test/helpers/time.coffee
+++ b/test/helpers/time.coffee
@@ -18,6 +18,27 @@ HOOKS = [
   'clearInterval'
 ]
 
+useFakeHrTime = (sandbox) ->
+  ticked = 0
+
+  sandbox.stub process, 'hrtime', (start) ->
+    now = [Math.floor(ticked / 1e3), (ticked % 1e3) * 1e6]
+
+    if start
+      [now[0] - start[0], now[1] - start[1]]
+    else
+      now
+
+  return tick: (ms) -> ticked += ms
+
+useFakeTimers = (sandbox, time, hooks...) ->
+  sinonClock = sandbox.useFakeTimers(time, hooks...)
+  hrClock = useFakeHrTime(sandbox)
+
+  return tick: (ms) ->
+    sinonClock.tick(ms)
+    hrClock.tick(ms)
+
 module.exports = (callback) ->
   Promise.using sandbox(), (s) ->
     # Resolve/then will let the timeout execute first before the fake timers
@@ -25,7 +46,7 @@ module.exports = (callback) ->
     Promise.resolve().then ->
       # We intentionally omit setImmediate/clearImmediate because freezing
       # those breaks a lot of request-based integration testing.
-      clock = s.useFakeTimers(Date.now(), HOOKS...)
+      clock = useFakeTimers(s, Date.now(), HOOKS...)
       Promise.try -> callback(clock.tick)
     # We are forcing a short timeout of 1000ms so that we can clean up the
     # timers before the next test if this does time out.


### PR DESCRIPTION
This lets us swap out the internals of `Stopwatch` to use the much more
accurate `hrtime()`. The hardest part was really adding an appropriate
stub to sinon, since it does not support it. We are still returning the
time in milliseconds for proper backwards-compatibility.
